### PR TITLE
Making ajax service singleton

### DIFF
--- a/src/remote/ajax.js
+++ b/src/remote/ajax.js
@@ -4,7 +4,8 @@
  * Released under the MIT license.
  */
 define([ "../component/service", "../pubsub/topic", "jquery", "../util/merge" ], function AjaxModule(Service, Topic, $, merge) {
-	return Service.extend({
+	var instance;
+	var Ctor = Service.extend({
 		displayName : "core/remote/ajax",
 
 		"hub/ajax" : function request(topic, settings, deferred) {
@@ -17,4 +18,12 @@ define([ "../component/service", "../pubsub/topic", "jquery", "../util/merge" ],
 			}, settings)).then(deferred.resolve, deferred.reject);
 		}
 	});
+
+	return function(){
+		if (!instance){
+			instance = Ctor();
+		}
+
+		return instance;
+	};
 });


### PR DESCRIPTION
refrain from duplicated ajax call when ajax service constructor is called multiple times 

let's say our query service heavily depend on ajax service, we don't wait for application widget to instantiate all services one by one. instead, we instantiate ajax service inside query service.
