### PR TITLE
console.debug is undefined in IE

### DIFF
--- a/logger/console.js
+++ b/logger/console.js
@@ -14,7 +14,7 @@ define([ "../component/base", "poly/function" ], function ConsoleLogger(Componen
 	 */
 
 	/*jshint devel:true*/
-	var CONSOLE = console;
+	var CONSOLE = window.console;
 
 	function noop() {}
 


### PR DESCRIPTION
In IE, console.debug is undefined, so bind will trigger an issue:
"SCRIPT5007: Unable to get property 'bind' of undefined or null reference"
