### PR TITLE
Remove `troopjs-log` mixin from core.composition

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,6 @@
     "bower_components"
   ],
   "dependencies": {
-    "troopjs-log": "^2",
     "troopjs-compose": "^4.0.1",
     "poly": "^0.6",
     "when": "^3.4",

--- a/composition.js
+++ b/composition.js
@@ -1,10 +1,7 @@
 /**
  * @license MIT http://troopjs.mit-license.org/
  */
-define([
-	"troopjs-compose/factory",
-	"troopjs-log/logger"
-], function ObjectBaseModule(Factory, logger) {
+define([ "troopjs-compose/factory" ], function (Factory) {
 	var INSTANCE_COUNTER = 0;
 	var INSTANCE_COUNT = "instanceCount";
 
@@ -12,7 +9,6 @@ define([
 	 * Base composition with instance count.
 	 * @class core.composition
 	 * @implement compose.composition
-	 * @mixin log.logger
 	 */
 
 	/**
@@ -43,7 +39,7 @@ define([
 		 * @property {Number}
 		 */
 		this[INSTANCE_COUNT] = ++INSTANCE_COUNTER;
-	}, logger, {
+	}, {
 		/**
 		 * The hierarchical namespace for this component that indicates it's functionality.
 		 * @protected


### PR DESCRIPTION
Having had some thoughts about logging in general I've come to these conclusions that make me want to remove `troopjs-log`.

* Exposing the full console API on every component is not clean
* `troopjs-log` can be configured to use external log frameworks, but no way to use `troopjs-log` from the outside.

@troopjs/maintainers thought?